### PR TITLE
Move the site to the new (common) Ubuntu 18.04 server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ clean:
 	rm -fr public
 
 publish:
-	rsync -aPvhe ssh --delete --exclude-from=/Users/harish/Scratch/Backup/exclude2 public/ ubuntu@harishnarayanan.org:/home/ubuntu/harishnarayanan.org
+	rsync -aPvhe ssh --delete --exclude-from=/Users/harish/Scratch/Backup/exclude2 public/ ubuntu@harishnarayanan.org:/home/ubuntu/sites/harishnarayanan.org
 
 checklinks:
 	wget --spider -o wget.log -e robots=off -w 1 -r -p https://harishnarayanan.org/

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ of things:
 
 1. Go to your favourite cloud provider (I use [Digital
    Ocean](https://m.do.co/c/e3559ea013de)) and provision a virtual
-   machine running [Ubuntu 16.04
-   LTS](http://releases.ubuntu.com/16.04/) to act as your new server.
+   machine running [Ubuntu 18.04
+   LTS](http://releases.ubuntu.com/18.04/) to act as your new server.
 
 2. Make sure you can SSH to this server. Edit
    `setup/servers/production` to reflect the domain name (or IP

--- a/setup/Vagrantfile
+++ b/setup/Vagrantfile
@@ -4,7 +4,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "geerlingguy/ubuntu1604"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.network "private_network", ip: "192.168.33.15"
 
   config.vm.provider "virtualbox" do |vb|

--- a/setup/roles/base/tasks/main.yml
+++ b/setup/roles/base/tasks/main.yml
@@ -45,7 +45,7 @@
     cache_valid_time=3600
   with_items:
     - fail2ban
-    - emacs24-nox
+    - emacs25-nox
     - htop
     - tree
     - git

--- a/setup/roles/encryption/tasks/main.yml
+++ b/setup/roles/encryption/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Add a custom repository for certbot
+  become: yes
+  apt_repository:
+    repo='ppa:certbot/certbot'
+    state=present
+
+- name: Install certbot
+  become: yes
+  apt:
+    name=python-certbot-nginx
+    state=latest
+    update_cache=yes
+
+- name: Generate certificates to enable HTTPS
+  become: yes
+  command:
+    "certbot certonly --nginx --non-interactive --agree-tos --email {{ user_email }} --keep-until-expiring --domain {{ domain_name }} --domain www.{{ domain_name }}"
+
+- name: Check if Diffie-Hellman key exchange parameters exist
+  become: yes
+  stat:
+    path: "{{ certificate_dir }}/dhparam.pem"
+  register: dhparam
+
+- name: Create parameters for Diffie-Hellman key exchange
+  become: yes
+  command:
+    "openssl dhparam -out {{ certificate_dir }}/dhparam.pem 4096"
+  when: dhparam.stat.exists == False
+
+  - name: Add a cron job to renew certificates when close to expiry
+  become: yes
+  cron:
+    name: Renew certificates using certbot
+    job: "certbot renew --quiet"
+    minute: 15
+    hour: 6

--- a/setup/roles/encryption/tasks/main.yml
+++ b/setup/roles/encryption/tasks/main.yml
@@ -29,7 +29,7 @@
     "openssl dhparam -out {{ certificate_dir }}/dhparam.pem 4096"
   when: dhparam.stat.exists == False
 
-  - name: Add a cron job to renew certificates when close to expiry
+- name: Add a cron job to renew certificates when close to expiry
   become: yes
   cron:
     name: Renew certificates using certbot

--- a/setup/roles/encryption/vars/main.yml
+++ b/setup/roles/encryption/vars/main.yml
@@ -1,3 +1,2 @@
 ---
-content_dir: "/home/{{ remote_user_name }}/sites"
 certificate_dir: "/etc/letsencrypt/live/{{ domain_name }}"

--- a/setup/roles/web/files/nginx.conf
+++ b/setup/roles/web/files/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes auto;
 pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
 	worker_connections 768;

--- a/setup/roles/web/files/nginx.conf
+++ b/setup/roles/web/files/nginx.conf
@@ -73,12 +73,14 @@ http {
 		image/x-icon
 		text/cache-manifest
 		text/css
+		text/javascript
 		text/plain
 		text/vcard
 		text/vnd.rim.location.xloc
 		text/vtt
 		text/x-component
-		text/x-cross-domain-policy;
+		text/x-cross-domain-policy
+		text/xml;
 
 	##
 	# Virtual Host Configs

--- a/setup/roles/web/tasks/main.yml
+++ b/setup/roles/web/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Import the GPG key for a custom nginx repository
-  become: yes
-  apt_key:
-    url=http://nginx.org/keys/nginx_signing.key
-    state=present
-
-- name: Add a custom repository for nginx
-  become: yes
-  apt_repository:
-    repo='deb http://nginx.org/packages/mainline/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx'
-    state=present
-
 - name: Install nginx
   become: yes
   apt:
@@ -25,53 +13,14 @@
     dest=/etc/nginx/nginx.conf
   notify: restart nginx
 
-- name: Add a custom repository for certbot
-  become: yes
-  apt_repository:
-    repo='ppa:certbot/certbot'
-    state=present
-
-- name: Install certbot
-  become: yes
-  apt:
-    name=python-certbot-nginx
-    state=latest
-    update_cache=yes
-
-- name: Generate certificates to enable HTTPS
-  become: yes
-  command:
-    "certbot certonly --nginx --non-interactive --agree-tos --email {{ user_email }} --keep-until-expiring --domain {{ domain_name }} --domain www.{{ domain_name }}"
-
-- name: Check if Diffie-Hellman key exchange parameters exist
-  become: yes
-  stat:
-    path: "{{ certificate_dir }}/dhparam.pem"
-  register: dhparam
-
-- name: Create parameters for Diffie-Hellman key exchange
-  become: yes
-  command:
-    "openssl dhparam -out {{ certificate_dir }}/dhparam.pem 4096"
-  when: dhparam.stat.exists == False
-
-- name: Setup the folders to hold site-specific nginx configuration
+- name: Delete the default website enabled by nginx
   become: yes
   file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - /etc/nginx/sites-available
-    - /etc/nginx/sites-enabled
+    path: /etc/nginx/sites-enabled/default
+    state: absent
   notify: restart nginx
 
-- name: Configure nginx to start on boot
-  become: yes
-  service:
-    name=nginx
-    enabled=yes
-
-- name: Create a folder to house the site content
+- name: Create a folder to house the website content
   file:
     path: "{{ content_dir }}/{{ domain_name }}"
     state: directory
@@ -101,10 +50,8 @@
     - { rule: 'allow', port: '80', proto: 'tcp' }
     - { rule: 'allow', port: '443', proto: 'tcp' }
 
-- name: Add a cron job to renew certificates when close to expiry
+- name: Enable the nginx service
   become: yes
-  cron:
-    name: Renew certificates using certbot
-    job: "certbot renew --quiet"
-    minute: 15
-    hour: 6
+  service:
+    name=nginx
+    enabled=yes

--- a/setup/servers/common
+++ b/setup/servers/common
@@ -1,0 +1,7 @@
+[webserver]
+common ansible_ssh_user=ubuntu
+
+[all:vars]
+remote_user_name = ubuntu
+user_name = "Harish Narayanan"
+user_email = hnarayanan@gmail.com

--- a/setup/servers/local
+++ b/setup/servers/local
@@ -1,7 +1,10 @@
 [webserver]
-192.168.33.15 ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key
+192.168.33.15
 
 [all:vars]
+ansible_user=vagrant
+ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key
+ansible_python_interpreter=/usr/bin/python3
 remote_user_name = vagrant
 user_name = "Harish Narayanan"
 user_email = hnarayanan@gmail.com

--- a/setup/servers/production
+++ b/setup/servers/production
@@ -1,3 +1,6 @@
+[encryption]
+harishnarayanan.org ansible_ssh_user=ubuntu
+
 [webserver]
 harishnarayanan.org ansible_ssh_user=ubuntu
 

--- a/setup/site.yml
+++ b/setup/site.yml
@@ -4,6 +4,13 @@
   roles:
     - base
 
+- name: "Setup certificates for transport layer security"
+  hosts: encryption
+  vars:
+    domain_name: harishnarayanan.org
+  roles:
+    - encryption
+
 - name: "Configure and deploy web server"
   hosts: webserver
   vars:


### PR DESCRIPTION
In the process of moving to a new common server, this set of changes brings in the following:

- Update the Ansible scripts to work on the latest Ubuntu LTS
- Split the `web` setup role into two parts, `encryption` for setting up TLS certificates, and a `web` role for websites
- Changes the filesystem location of the hosted files, to account for a new shared host serving multiple sites

Closes #43.